### PR TITLE
Set sell mode

### DIFF
--- a/scripts/UI/BuildingInfo.gd
+++ b/scripts/UI/BuildingInfo.gd
@@ -239,6 +239,7 @@ func set_building_selling(selling: bool) -> void:
 	current_building.currently_selling = selling
 	if selling:
 		sell_store_status_label.text = "Selling"
+		current_building._output_resources()
 	else:
 		sell_store_status_label.text = "Storing"
 		

--- a/scripts/buildings/gathering_building.gd
+++ b/scripts/buildings/gathering_building.gd
@@ -28,7 +28,7 @@ func check_if_can_produce() -> bool:
 	if missing_input:
 		return false
 		
-	if can_be_output_overflow:
+	if can_be_output_overflow and not currently_selling:
 		return false
 	
 	if !near_resource:

--- a/scripts/buildings/production_building.gd
+++ b/scripts/buildings/production_building.gd
@@ -81,7 +81,7 @@ func check_if_can_produce() -> bool:
 	if missing_input:
 		return false
 		
-	if can_be_output_overflow:
+	if can_be_output_overflow and not currently_selling:
 		return false
 	
 	return true


### PR DESCRIPTION
Made a change so that buildings whose storage is full (meaning overflow) when switching to sell mode will sell the overflow production instead of needing to make space for the next production cycle of produced goods.