### PR TITLE
Collisionshape size increase for gear factory and warehouse

### DIFF
--- a/scenes/buildings/production_buildings/gear_factory.tscn
+++ b/scenes/buildings/production_buildings/gear_factory.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://1md2vp0etsy7" path="res://scenes/buildings/animation/place_particle_medium.tscn" id="5_qi7j2"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_essim"]
+size = Vector2(64, 64)
 
 [sub_resource type="Curve" id="Curve_f8yp3"]
 _data = [Vector2(0, 0.5), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]

--- a/scenes/buildings/storage_buildings/warehouse.tscn
+++ b/scenes/buildings/storage_buildings/warehouse.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://1md2vp0etsy7" path="res://scenes/buildings/animation/place_particle_medium.tscn" id="5_0mb1i"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_0igec"]
-size = Vector2(32, 32)
+size = Vector2(64, 64)
 
 [node name="Warehouse" type="StaticBody2D"]
 script = ExtResource("1_5pk0i")


### PR DESCRIPTION
Increased the size of the collisionshape2D for the gear factory and the warehouse to match their perceived sizes